### PR TITLE
Saved lane name as environment variable

### DIFF
--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -5,6 +5,7 @@ module Fastlane
       key = key.to_sym
       Helper.log.info "Driving the lane '#{key}'".green
       Actions.lane_context[Actions::SharedValues::LANE_NAME] = key
+      ENV["FASTLANE_LANE_NAME"] = key
 
       return_val = nil
 


### PR DESCRIPTION
### Summary

Saved lane name as environment variable
### Why

Give the opportunity to all fastlane tools to  invoke different actions based on the lane name
### Example

Use Appfile configuration `for_lane block` as fastlane lane [#146](https://github.com/KrauseFx/fastlane/issues/146)
